### PR TITLE
feat(storage): persist library across reloads

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,6 +17,7 @@ const App: React.FC = () => {
   const { toast } = useToast();
   const playlist = usePlaylist();
   const player = usePlayer({
+    isReady: playlist.isReady,
     queue: playlist.queue,
     originalQueue: playlist.originalQueue,
     updateSongInQueue: playlist.updateSongInQueue,
@@ -177,8 +178,7 @@ const App: React.FC = () => {
   };
 
   const handleAddToQueue = (song: Song) => {
-    playlist.setQueue((prev) => [...prev, song]);
-    playlist.setOriginalQueue((prev) => [...prev, song]);
+    playlist.addSongs([song]);
   };
 
   const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {

--- a/components/SearchModal.tsx
+++ b/components/SearchModal.tsx
@@ -200,12 +200,15 @@ const SearchModal: React.FC<SearchModalProps> = ({
   };
 
   const playNeteaseTrack = (track: NeteaseTrackInfo) => {
+    const origin = getNeteaseAudioUrl(track.id);
     const song: Song = {
       id: track.id,
       title: track.title,
       artist: track.artist,
       coverUrl: track.coverUrl.replace("http:", "https:"),
-      fileUrl: getNeteaseAudioUrl(track.id),
+      fileUrl: origin,
+      source: "remote",
+      origin,
       isNetease: true,
       neteaseId: track.neteaseId,
       album: track.album,
@@ -216,12 +219,15 @@ const SearchModal: React.FC<SearchModalProps> = ({
   };
 
   const addNeteaseToQueue = (track: NeteaseTrackInfo) => {
+    const origin = getNeteaseAudioUrl(track.id);
     const song: Song = {
       id: track.id,
       title: track.title,
       artist: track.artist,
       coverUrl: track.coverUrl.replace("http:", "https:"),
-      fileUrl: getNeteaseAudioUrl(track.id),
+      fileUrl: origin,
+      source: "remote",
+      origin,
       isNetease: true,
       neteaseId: track.neteaseId,
       album: track.album,

--- a/hooks/usePlayer.ts
+++ b/hooks/usePlayer.ts
@@ -10,6 +10,10 @@ import { Song, PlayState, PlayMode } from "../types";
 import { extractColors, shuffleArray } from "../services/utils";
 import { parseLyrics } from "../services/lyrics";
 import {
+  loadPlaybackSnapshot,
+  savePlaybackSnapshot,
+} from "../services/libraryStore";
+import {
   fetchLyricsById,
   searchAndMatchLyrics,
   MatchedLyricsResult,
@@ -19,6 +23,7 @@ import { audioResourceCache } from "../services/cache";
 type MatchStatus = "idle" | "matching" | "success" | "failed";
 
 interface UsePlayerParams {
+  isReady: boolean;
   queue: Song[];
   originalQueue: Song[];
   updateSongInQueue: (id: string, updates: Partial<Song>) => void;
@@ -46,17 +51,20 @@ const withTimeout = <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
 };
 
 export const usePlayer = ({
+  isReady,
   queue,
   originalQueue,
   updateSongInQueue,
   setQueue,
   setOriginalQueue,
 }: UsePlayerParams) => {
+  const savedRef = useRef(loadPlaybackSnapshot());
+  const restoredRef = useRef(false);
   const [currentIndex, setCurrentIndex] = useState(-1);
   const [playState, setPlayState] = useState<PlayState>(PlayState.PAUSED);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
-  const [playMode, setPlayMode] = useState<PlayMode>(PlayMode.LOOP_ALL);
+  const [playMode, setPlayMode] = useState<PlayMode>(savedRef.current.playMode);
   const [matchStatus, setMatchStatus] = useState<MatchStatus>("idle");
   const audioRef = useRef<HTMLAudioElement>(null);
   const isSeekingRef = useRef(false);
@@ -482,6 +490,30 @@ export const usePlayer = ({
       })
       .catch((err) => console.warn("Color extraction failed", err));
   }, [currentSong, updateSongInQueue]);
+
+  useEffect(() => {
+    if (!isReady || restoredRef.current) return;
+
+    restoredRef.current = true;
+
+    if (queue.length === 0) return;
+
+    const idx = savedRef.current.songId
+      ? queue.findIndex((song) => song.id === savedRef.current.songId)
+      : -1;
+
+    setCurrentIndex(idx !== -1 ? idx : 0);
+    setMatchStatus("idle");
+  }, [isReady, queue]);
+
+  useEffect(() => {
+    if (!isReady || !restoredRef.current) return;
+
+    savePlaybackSnapshot({
+      songId: currentSong?.id ?? null,
+      playMode,
+    });
+  }, [isReady, currentSong?.id, playMode]);
 
   useEffect(() => {
     if (queue.length === 0) {

--- a/hooks/usePlaylist.ts
+++ b/hooks/usePlaylist.ts
@@ -1,5 +1,13 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Song } from "../types";
+import {
+  deleteLocalFiles,
+  hydrateLibrarySnapshot,
+  loadLibrarySnapshot,
+  revokeLocalUrls,
+  saveLibrarySnapshot,
+  saveLocalFiles,
+} from "../services/libraryStore";
 import {
   extractColors,
   parseAudioMetadata,
@@ -57,6 +65,79 @@ export interface ImportResult {
 export const usePlaylist = () => {
   const [queue, setQueue] = useState<Song[]>([]);
   const [originalQueue, setOriginalQueue] = useState<Song[]>([]);
+  const [isReady, setIsReady] = useState(false);
+  const urlsRef = useRef(new Map<string, string>());
+
+  const storeUrl = useCallback((id: string, url: string) => {
+    const prev = urlsRef.current.get(id);
+    if (prev && prev !== url) {
+      URL.revokeObjectURL(prev);
+    }
+    urlsRef.current.set(id, url);
+  }, []);
+
+  const dropUrls = useCallback((ids: string[]) => {
+    ids.forEach((id) => {
+      const url = urlsRef.current.get(id);
+      if (!url) {
+        return;
+      }
+
+      URL.revokeObjectURL(url);
+      urlsRef.current.delete(id);
+    });
+  }, []);
+
+  useEffect(() => {
+    let canceled = false;
+
+    const load = async () => {
+      try {
+        const snap = await loadLibrarySnapshot();
+        if (!snap || canceled) {
+          return;
+        }
+
+        const data = await hydrateLibrarySnapshot(snap);
+        if (canceled) {
+          revokeLocalUrls([...data.queue, ...data.originalQueue]);
+          return;
+        }
+
+        [...data.queue, ...data.originalQueue].forEach((song) => {
+          if (song.source === "local" && song.fileUrl.startsWith("blob:")) {
+            storeUrl(song.id, song.fileUrl);
+          }
+        });
+
+        setQueue(data.queue);
+        setOriginalQueue(data.originalQueue);
+      } catch (err) {
+        console.warn("Failed to restore library", err);
+      } finally {
+        if (!canceled) {
+          setIsReady(true);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      canceled = true;
+      dropUrls(Array.from(urlsRef.current.keys()));
+    };
+  }, [dropUrls, storeUrl]);
+
+  useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
+    saveLibrarySnapshot(queue, originalQueue).catch((err) => {
+      console.warn("Failed to save library", err);
+    });
+  }, [isReady, queue, originalQueue]);
 
   const updateSongInQueue = useCallback(
     (id: string, updates: Partial<Song>) => {
@@ -76,18 +157,34 @@ export const usePlaylist = () => {
     setQueue((prev) => [...prev, ...songs]);
   }, []);
 
+  const addSongs = useCallback((songs: Song[]) => {
+    appendSongs(songs);
+  }, [appendSongs]);
+
   const removeSongs = useCallback((ids: string[]) => {
     if (ids.length === 0) return;
+    const locals = new Set<string>();
+
     setQueue((prev) => {
       prev.forEach((song) => {
         if (ids.includes(song.id) && song.fileUrl && !song.fileUrl.startsWith("blob:")) {
           audioResourceCache.delete(song.fileUrl);
         }
+        if (ids.includes(song.id) && song.source === "local") {
+          locals.add(song.id);
+        }
       });
       return prev.filter((song) => !ids.includes(song.id));
     });
     setOriginalQueue((prev) => prev.filter((song) => !ids.includes(song.id)));
-  }, []);
+    if (locals.size > 0) {
+      const list = Array.from(locals);
+      dropUrls(list);
+      deleteLocalFiles(list).catch((err) => {
+        console.warn("Failed to delete local files", err);
+      });
+    }
+  }, [dropUrls]);
 
   const addLocalFiles = useCallback(
     async (files: FileList | File[]) => {
@@ -130,7 +227,6 @@ export const usePlaylist = () => {
       // Process audio files
       for (let i = 0; i < audioFiles.length; i++) {
         const file = audioFiles[i];
-        const url = URL.createObjectURL(file);
         const basename = file.name.replace(/\.[^/.]+$/, "");
         let title = basename;
         let artist = "Unknown Artist";
@@ -211,7 +307,8 @@ export const usePlaylist = () => {
           id: `local-${Date.now()}-${i}`,
           title,
           artist,
-          fileUrl: url,
+          fileUrl: "",
+          source: "local",
           coverUrl,
           lyrics,
           colors: colors && colors.length > 0 ? colors : undefined,
@@ -219,10 +316,27 @@ export const usePlaylist = () => {
         });
       }
 
+      newSongs.forEach((song, idx) => {
+        const url = URL.createObjectURL(audioFiles[idx]);
+        song.fileUrl = url;
+        storeUrl(song.id, url);
+      });
+
+      try {
+        await saveLocalFiles(
+          newSongs.map((song, idx) => ({
+            id: song.id,
+            file: audioFiles[idx],
+          })),
+        );
+      } catch (err) {
+        console.warn("Failed to persist local files", err);
+      }
+
       appendSongs(newSongs);
       return newSongs;
     },
-    [appendSongs],
+    [appendSongs, storeUrl],
   );
 
   const importFromUrl = useCallback(
@@ -242,9 +356,12 @@ export const usePlaylist = () => {
         if (parsed.type === "playlist") {
           const songs = await fetchNeteasePlaylist(parsed.id);
           songs.forEach((song) => {
+            const origin = getNeteaseAudioUrl(song.id);
             newSongs.push({
               ...song,
-              fileUrl: getNeteaseAudioUrl(song.id),
+              fileUrl: origin,
+              source: "remote",
+              origin,
               lyrics: [],
               colors: [],
               needsLyricsMatch: true,
@@ -253,9 +370,12 @@ export const usePlaylist = () => {
         } else {
           const song = await fetchNeteaseSong(parsed.id);
           if (song) {
+            const origin = getNeteaseAudioUrl(song.id);
             newSongs.push({
               ...song,
-              fileUrl: getNeteaseAudioUrl(song.id),
+              fileUrl: origin,
+              source: "remote",
+              origin,
               lyrics: [],
               colors: [],
               needsLyricsMatch: true,
@@ -288,7 +408,9 @@ export const usePlaylist = () => {
   return {
     queue,
     originalQueue,
+    isReady,
     updateSongInQueue,
+    addSongs,
     removeSongs,
     addLocalFiles,
     importFromUrl,

--- a/services/libraryStore.ts
+++ b/services/libraryStore.ts
@@ -1,0 +1,353 @@
+import { PlayMode, Song } from "../types";
+
+const DB = "aura-music";
+const VER = 1;
+const META = "meta";
+const FILES = "files";
+const SNAP = "playlist";
+const PLAYBACK = "aura:playback";
+
+const MODES = [PlayMode.LOOP_ALL, PlayMode.LOOP_ONE, PlayMode.SHUFFLE];
+
+export interface StoredSong {
+  id: string;
+  title: string;
+  artist: string;
+  source: "local" | "remote";
+  origin?: string;
+  coverUrl?: string;
+  lyrics?: Song["lyrics"];
+  colors?: string[];
+  needsLyricsMatch?: boolean;
+  isNetease?: boolean;
+  neteaseId?: string;
+  album?: string;
+}
+
+export interface LibrarySnapshot {
+  queue: StoredSong[];
+  originalQueue: StoredSong[];
+}
+
+export interface HydratedSnapshot {
+  queue: Song[];
+  originalQueue: Song[];
+}
+
+export interface PlaybackSnapshot {
+  songId: string | null;
+  playMode: PlayMode;
+}
+
+const getDefaultPlayback = (): PlaybackSnapshot => ({
+  songId: null,
+  playMode: PlayMode.LOOP_ALL,
+});
+
+const hasWindow = () => {
+  return typeof window !== "undefined";
+};
+
+const openDb = async (): Promise<IDBDatabase | null> => {
+  if (!hasWindow() || !("indexedDB" in window)) {
+    return null;
+  }
+
+  return await new Promise((resolve, reject) => {
+    const req = window.indexedDB.open(DB, VER);
+
+    req.onupgradeneeded = () => {
+      const db = req.result;
+
+      if (!db.objectStoreNames.contains(META)) {
+        db.createObjectStore(META);
+      }
+
+      if (!db.objectStoreNames.contains(FILES)) {
+        db.createObjectStore(FILES);
+      }
+    };
+
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("Failed to open library database"));
+  });
+};
+
+const waitReq = <T>(req: IDBRequest<T>): Promise<T> => {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("IndexedDB request failed"));
+  });
+};
+
+const waitTx = (tx: IDBTransaction): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onabort = () => reject(tx.error ?? new Error("IndexedDB transaction aborted"));
+    tx.onerror = () => reject(tx.error ?? new Error("IndexedDB transaction failed"));
+  });
+};
+
+const runDb = async <T>(
+  names: string[],
+  mode: IDBTransactionMode,
+  run: (tx: IDBTransaction) => Promise<T>,
+): Promise<T | null> => {
+  const db = await openDb();
+  if (!db) {
+    return null;
+  }
+
+  const tx = db.transaction(names, mode);
+
+  try {
+    const value = await run(tx);
+    await waitTx(tx);
+    return value;
+  } finally {
+    db.close();
+  }
+};
+
+export const toStoredSong = (song: Song): StoredSong => {
+  const source = song.source ?? (song.fileUrl.startsWith("blob:") ? "local" : "remote");
+
+  return {
+    id: song.id,
+    title: song.title,
+    artist: song.artist,
+    source,
+    origin: source === "remote" ? song.origin ?? song.fileUrl : undefined,
+    coverUrl: song.coverUrl,
+    lyrics: song.lyrics,
+    colors: song.colors,
+    needsLyricsMatch: song.needsLyricsMatch,
+    isNetease: song.isNetease,
+    neteaseId: song.neteaseId,
+    album: song.album,
+  };
+};
+
+export const fromStoredSong = (song: StoredSong, fileUrl?: string): Song | null => {
+  if (song.source === "local") {
+    if (!fileUrl) {
+      return null;
+    }
+
+    return {
+      id: song.id,
+      title: song.title,
+      artist: song.artist,
+      fileUrl,
+      source: "local",
+      coverUrl: song.coverUrl,
+      lyrics: song.lyrics,
+      colors: song.colors,
+      needsLyricsMatch: song.needsLyricsMatch,
+      isNetease: song.isNetease,
+      neteaseId: song.neteaseId,
+      album: song.album,
+    };
+  }
+
+  const origin = song.origin ?? "";
+  if (!origin) {
+    return null;
+  }
+
+  return {
+    id: song.id,
+    title: song.title,
+    artist: song.artist,
+    fileUrl: origin,
+    source: "remote",
+    origin,
+    coverUrl: song.coverUrl,
+    lyrics: song.lyrics,
+    colors: song.colors,
+    needsLyricsMatch: song.needsLyricsMatch,
+    isNetease: song.isNetease,
+    neteaseId: song.neteaseId,
+    album: song.album,
+  };
+};
+
+export const buildLibrarySnapshot = (
+  queue: Song[],
+  originalQueue: Song[],
+): LibrarySnapshot => {
+  return {
+    queue: queue.map(toStoredSong),
+    originalQueue: originalQueue.map(toStoredSong),
+  };
+};
+
+export const saveLibrarySnapshot = async (
+  queue: Song[],
+  originalQueue: Song[],
+) => {
+  const snap = buildLibrarySnapshot(queue, originalQueue);
+
+  await runDb([META], "readwrite", async (tx) => {
+    await waitReq(tx.objectStore(META).put(snap, SNAP));
+    return undefined;
+  });
+};
+
+export const loadLibrarySnapshot = async (): Promise<LibrarySnapshot | null> => {
+  const value = await runDb([META], "readonly", async (tx) => {
+    const raw = await waitReq(tx.objectStore(META).get(SNAP));
+    if (!raw || typeof raw !== "object") {
+      return null;
+    }
+
+    const snap = raw as Partial<LibrarySnapshot>;
+    return {
+      queue: Array.isArray(snap.queue) ? snap.queue : [],
+      originalQueue: Array.isArray(snap.originalQueue) ? snap.originalQueue : [],
+    };
+  });
+
+  return value ?? null;
+};
+
+export const saveLocalFiles = async (list: Array<{ id: string; file: Blob }>) => {
+  if (list.length === 0) {
+    return;
+  }
+
+  await runDb([FILES], "readwrite", async (tx) => {
+    const store = tx.objectStore(FILES);
+    await Promise.all(list.map((item) => waitReq(store.put(item.file, item.id))));
+    return undefined;
+  });
+};
+
+export const loadLocalFile = async (id: string): Promise<Blob | null> => {
+  const value = await runDb([FILES], "readonly", async (tx) => {
+    const raw = await waitReq(tx.objectStore(FILES).get(id));
+    return raw instanceof Blob ? raw : null;
+  });
+
+  return value ?? null;
+};
+
+export const deleteLocalFiles = async (ids: string[]) => {
+  if (ids.length === 0) {
+    return;
+  }
+
+  await runDb([FILES], "readwrite", async (tx) => {
+    const store = tx.objectStore(FILES);
+    await Promise.all(ids.map((id) => waitReq(store.delete(id))));
+    return undefined;
+  });
+};
+
+export const hydrateLibrarySnapshot = async (
+  snap: LibrarySnapshot,
+): Promise<HydratedSnapshot> => {
+  const urls = new Map<string, string>();
+
+  const hydrate = async (list: StoredSong[]) => {
+    const out: Song[] = [];
+
+    for (const item of list) {
+      if (item.source === "local") {
+        let url = urls.get(item.id);
+
+        if (!url) {
+          const file = await loadLocalFile(item.id);
+          if (!file) {
+            continue;
+          }
+
+          url = URL.createObjectURL(file);
+          urls.set(item.id, url);
+        }
+
+        const song = fromStoredSong(item, url);
+        if (song) {
+          out.push(song);
+        }
+
+        continue;
+      }
+
+      const song = fromStoredSong(item);
+      if (song) {
+        out.push(song);
+      }
+    }
+
+    return out;
+  };
+
+  return {
+    queue: await hydrate(snap.queue),
+    originalQueue: await hydrate(snap.originalQueue),
+  };
+};
+
+export const revokeLocalUrls = (list: Song[]) => {
+  if (!hasWindow()) {
+    return;
+  }
+
+  const seen = new Set<string>();
+
+  list.forEach((song) => {
+    if (song.source !== "local") {
+      return;
+    }
+
+    if (!song.fileUrl.startsWith("blob:")) {
+      return;
+    }
+
+    if (seen.has(song.fileUrl)) {
+      return;
+    }
+
+    seen.add(song.fileUrl);
+    URL.revokeObjectURL(song.fileUrl);
+  });
+};
+
+export const parsePlaybackSnapshot = (raw: string | null): PlaybackSnapshot => {
+  if (!raw) {
+    return getDefaultPlayback();
+  }
+
+  try {
+    const value = JSON.parse(raw) as Partial<PlaybackSnapshot>;
+    const playMode = MODES.includes(value.playMode as PlayMode)
+      ? (value.playMode as PlayMode)
+      : PlayMode.LOOP_ALL;
+
+    return {
+      songId: typeof value.songId === "string" && value.songId.trim()
+        ? value.songId
+        : null,
+      playMode,
+    };
+  } catch {
+    return getDefaultPlayback();
+  }
+};
+
+export const loadPlaybackSnapshot = (): PlaybackSnapshot => {
+  if (!hasWindow() || !("localStorage" in window)) {
+    return getDefaultPlayback();
+  }
+
+  return parsePlaybackSnapshot(window.localStorage.getItem(PLAYBACK));
+};
+
+export const savePlaybackSnapshot = (snap: PlaybackSnapshot) => {
+  if (!hasWindow() || !("localStorage" in window)) {
+    return;
+  }
+
+  window.localStorage.setItem(PLAYBACK, JSON.stringify(snap));
+};

--- a/services/lyrics/netease.ts
+++ b/services/lyrics/netease.ts
@@ -551,7 +551,12 @@ export const parseNeteaseLyrics = (
 
   // If LRC content provided, use as base and enrich
   if (lrcContent?.trim()) {
-    const baseLines = parseLrc(lrcContent).filter(line => !line.isInterlude);
+    const baseLines = parseLrc(lrcContent)
+      .filter(line => !line.isInterlude)
+      .map(line => ({
+        ...line,
+        endTime: undefined,
+      }));
     const enriched = enrichWithWordTiming(baseLines, tokens);
     const withInterludes = insertInterludes(enriched);
     const filtered = filterShortInterludes(withInterludes);

--- a/tests/library_store.test.ts
+++ b/tests/library_store.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test";
+import {
+  fromStoredSong,
+  parsePlaybackSnapshot,
+  toStoredSong,
+} from "../services/libraryStore";
+import { PlayMode, Song } from "../types";
+
+test("remote songs keep their original source url", () => {
+  const song: Song = {
+    id: "42",
+    title: "Aura",
+    artist: "Test",
+    fileUrl: "https://redirected.example/file.mp3",
+    source: "remote",
+    origin: "https://api.example/audio?id=42",
+  };
+
+  expect(toStoredSong(song)).toEqual({
+    id: "42",
+    title: "Aura",
+    artist: "Test",
+    source: "remote",
+    origin: "https://api.example/audio?id=42",
+    coverUrl: undefined,
+    lyrics: undefined,
+    colors: undefined,
+    needsLyricsMatch: undefined,
+    isNetease: undefined,
+    neteaseId: undefined,
+    album: undefined,
+  });
+});
+
+test("remote songs fall back to fileUrl when origin is missing", () => {
+  const song: Song = {
+    id: "43",
+    title: "Glow",
+    artist: "Test",
+    fileUrl: "https://api.example/audio?id=43",
+  };
+
+  expect(toStoredSong(song).origin).toBe("https://api.example/audio?id=43");
+});
+
+test("local songs are restored from stored metadata and blob url", () => {
+  const song = fromStoredSong(
+    {
+      id: "local-1",
+      title: "Local",
+      artist: "Singer",
+      source: "local",
+      colors: ["rgb(1, 2, 3)"],
+    },
+    "blob:test",
+  );
+
+  expect(song).toEqual({
+    id: "local-1",
+    title: "Local",
+    artist: "Singer",
+    fileUrl: "blob:test",
+    source: "local",
+    coverUrl: undefined,
+    lyrics: undefined,
+    colors: ["rgb(1, 2, 3)"],
+    needsLyricsMatch: undefined,
+    isNetease: undefined,
+    neteaseId: undefined,
+    album: undefined,
+  });
+});
+
+test("playback snapshot parser keeps valid data and rejects bad modes", () => {
+  expect(
+    parsePlaybackSnapshot(JSON.stringify({
+      songId: "abc",
+      playMode: PlayMode.SHUFFLE,
+    })),
+  ).toEqual({
+    songId: "abc",
+    playMode: PlayMode.SHUFFLE,
+  });
+
+  expect(
+    parsePlaybackSnapshot(JSON.stringify({
+      songId: "abc",
+      playMode: 99,
+    })),
+  ).toEqual({
+    songId: "abc",
+    playMode: PlayMode.LOOP_ALL,
+  });
+
+  expect(parsePlaybackSnapshot("not-json")).toEqual({
+    songId: null,
+    playMode: PlayMode.LOOP_ALL,
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -26,6 +26,8 @@ export interface Song {
   title: string;
   artist: string;
   fileUrl: string;
+  source?: "local" | "remote";
+  origin?: string;
   coverUrl?: string;
   lyrics?: LyricLine[];
   colors?: string[]; // Array of dominant colors


### PR DESCRIPTION
## Summary
- persist the queue and original queue across reloads, storing local imports in IndexedDB and remote tracks with their original pre-redirect source URLs
- restore the previously selected song and loop mode from local state so playback context survives refreshes without forcing autoplay
- add focused persistence tests and wire queue additions through the shared playlist path

## Testing
- `bun test tests/library_store.test.ts`
- `bun run build`
- `bun test tests` *(currently still has pre-existing unrelated failures in `tests/ttml.test.ts` and `tests/yrc.test.ts` on this branch)*

Closes #2