### PR TITLE
fix(lyrics): avoid premature YRC interludes

### DIFF
--- a/services/lyrics/netease.ts
+++ b/services/lyrics/netease.ts
@@ -551,7 +551,12 @@ export const parseNeteaseLyrics = (
 
   // If LRC content provided, use as base and enrich
   if (lrcContent?.trim()) {
-    const baseLines = parseLrc(lrcContent).filter(line => !line.isInterlude);
+    const baseLines = parseLrc(lrcContent)
+      .filter(line => !line.isInterlude)
+      .map(line => ({
+        ...line,
+        endTime: undefined,
+      }));
     const enriched = enrichWithWordTiming(baseLines, tokens);
     const withInterludes = insertInterludes(enriched);
     const filtered = filterShortInterludes(withInterludes);


### PR DESCRIPTION
## Summary
- clear inherited LRC `endTime` values before applying YRC word timing
- recompute interlude insertion from enriched timings so false mid-line gaps are not created
- fixes the failing `npm test` YRC enrichment case

## Testing
- npm test